### PR TITLE
feat: send more data to slack on order_created event

### DIFF
--- a/graphql/subscriptions/OrderCreatedSubscription.graphql
+++ b/graphql/subscriptions/OrderCreatedSubscription.graphql
@@ -3,7 +3,38 @@ subscription OrderCreatedSubscription {
     ... on OrderCreated {
       order {
         id
-        userEmail
+        number
+        user {
+          email
+          firstName
+          lastName
+        }
+        shippingAddress {
+          streetAddress1
+          city
+          postalCode
+          country {
+            country
+          }
+        }
+        subtotal {
+          gross {
+            amount
+            currency
+          }
+        }
+        shippingPrice {
+          gross {
+            amount
+            currency
+          }
+        }
+        total {
+          gross {
+            amount
+            currency
+          }
+        }
       }
     }
   }

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -1,8 +1,13 @@
+import { Order } from "../generated/graphql";
+
 export const sendSlackMessage = async (
   to: string,
-  data: { userEmail: string; saleorDomain: string; orderId: string }
+  data: { order: Order; saleorDomain: string }
 ) => {
-  const { userEmail, saleorDomain, orderId } = data;
+  const {
+    saleorDomain,
+    order: { id, number, user, shippingAddress, subtotal, shippingPrice, total },
+  } = data;
 
   const response = await fetch(to, {
     method: "POST",
@@ -12,7 +17,28 @@ export const sendSlackMessage = async (
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `New order created for ${userEmail} 🎉\n\n<https://${saleorDomain}/dashboard/orders/${orderId}|View order>`,
+            text: `Order <https://${saleorDomain}/dashboard/orders/${id}|#${number}> has been created 🎉`,
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `*Customer*\n${user?.firstName} ${user?.lastName}\n${user?.email}`,
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `*Shipping Address*\n${shippingAddress?.streetAddress1}\n${shippingAddress?.postalCode} ${shippingAddress?.city}\n${shippingAddress?.country.country}`,
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `*Subtotal*\n${subtotal.gross.amount} ${subtotal.gross.currency}\n*Shipping*\n${shippingPrice.gross.amount} ${shippingPrice.gross.currency}\n*Total*\n${total.gross.amount} ${total.gross.currency}`,
           },
         },
       ],

--- a/pages/api/webhooks/order-created.ts
+++ b/pages/api/webhooks/order-created.ts
@@ -18,15 +18,16 @@ const handler: Handler = async (request) => {
   const webhookUrl = await getValue(saleorDomain, "WEBHOOK_URL");
 
   const context = request.params;
-  const {
-    order: { id, userEmail },
-  } = context;
+  const { order } = context;
 
-  if (!id) {
+  if (!order.id) {
     return Response.BadRequest({ success: false, message: "No order id." });
   }
 
-  const response = await sendSlackMessage(webhookUrl, { userEmail, saleorDomain, orderId: id });
+  const response = await sendSlackMessage(webhookUrl, {
+    saleorDomain,
+    order,
+  });
 
   if (response.status !== 200) {
     const errorMessage = await response.text();


### PR DESCRIPTION
## What was done

This PR fixes #10. I've added new info to Slack messages:

![CleanShot 2022-10-12 at 14 53 51@2x](https://user-images.githubusercontent.com/9116238/195347787-7ba378be-1d24-4439-8dba-e6b8b1eed1ce.jpg)

## How to test it
1. Checkout to this PR and run the app via `pnpm run dev` & `saleor app tunnel`
2. Follow `Instructions` from the app in the Dashboard view. You can use [docs](https://github.com/saleor/saleor-app-slack/blob/main/docs/setup-slack-app.md) as well. I propose you use the `#saleor-bot-test` slack channel.
3. Create new order