### PR TITLE
feat: prepare slack manifest

### DIFF
--- a/pages/api/manifest.ts
+++ b/pages/api/manifest.ts
@@ -32,8 +32,16 @@ const handler = createManifestHandler({
       ],
     };
 
-    return manifest;
-  },
-});
+  const manifest = {
+    id: "saleor.app",
+    version: packageJson.version,
+    name: packageJson.name,
+    permissions: [],
+    appUrl: baseURL,
+    tokenTargetUrl: `${baseURL}/api/register`,
+    webhooks,
+    extensions: [],
+  };
 
 export default withSentry(handler);
+ 

--- a/pages/api/manifest.ts
+++ b/pages/api/manifest.ts
@@ -17,31 +17,15 @@ const handler = createManifestHandler({
       name: packageJson.name,
       tokenTargetUrl: `${context.appBaseUrl}/api/register`,
       appUrl: context.appBaseUrl,
-      permissions: ["MANAGE_ORDERS"],
+      permissions: [],
       id: "saleor.app",
       version: packageJson.version,
       webhooks,
-      extensions: [
-        {
-          label: "Guest orders",
-          mount: "NAVIGATION_ORDERS",
-          target: "APP_PAGE",
-          permissions: ["MANAGE_ORDERS"],
-          url: "/orders",
-        },
-      ],
+      extensions: [],
     };
 
-  const manifest = {
-    id: "saleor.app",
-    version: packageJson.version,
-    name: packageJson.name,
-    permissions: [],
-    appUrl: baseURL,
-    tokenTargetUrl: `${baseURL}/api/register`,
-    webhooks,
-    extensions: [],
-  };
+    return manifest;
+  },
+});
 
 export default withSentry(handler);
- 

--- a/pages/api/slack-app-manifest.ts
+++ b/pages/api/slack-app-manifest.ts
@@ -8,7 +8,7 @@ const handler: Handler = () => {
   const manifest = {
     display_information: {
       name: "Saleor",
-      description: "Receive new orders to your Slack channel",
+      description: "Receive notifications to your Slack channel",
       background_color: "#231e49",
     },
     features: {

--- a/pages/api/slack-app-manifest.ts
+++ b/pages/api/slack-app-manifest.ts
@@ -7,11 +7,13 @@ import { Response } from "retes/response";
 const handler: Handler = () => {
   const manifest = {
     display_information: {
-      name: "Saleor bot",
+      name: "Saleor",
+      description: "Receive new orders to your Slack channel",
+      background_color: "#231e49",
     },
     features: {
       bot_user: {
-        display_name: "Saleor bot",
+        display_name: "Saleor",
         always_online: false,
       },
     },


### PR DESCRIPTION
## What was done
* Changed a bit values in Slack app manifest to be consistent with [marketplace](https://github.com/saleor/saleor-app-marketplace/pull/95)
* Removed not needed extensions & permissions from application
* Fixes #11 

## Outstanding issues
* Right now you can add the Slack app logo in the manifest - the user will need to do this manually 😞 . It should be possible in the new version of API (currently in beta)

## How to test
1. Clone this PR and run the app in development mode (`pnpm run dev` & `saleor app tunnel`).
2. Follow `Instructions` from the app in the Dashboard view.