### PR TITLE
fix: bump app-sdk and remove ts-ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "4.0.0-alpha.61",
-    "@saleor/app-sdk": "0.13.2",
+    "@saleor/app-sdk": "0.16.0",
     "@saleor/macaw-ui": "^0.6.3",
     "@sentry/nextjs": "^7.12.1",
     "@urql/exchange-auth": "^1.0.0",

--- a/pages/configuration.tsx
+++ b/pages/configuration.tsx
@@ -218,8 +218,6 @@ const ConfigurationWithAuth = withAuthorization({
   dashboardTokenInvalid: <AccessWarning cause="invalid_access_token" />,
 })(Configuration);
 
-// TODO: remove this ignore when https://github.com/saleor/saleor-app-sdk/pull/82 is released
-// @ts-ignore
 ConfigurationWithAuth.getLayout = (page: ReactElement) => (
   <div>
     <Card style={{ marginBottom: 40 }}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ specifiers:
   '@material-ui/core': ^4.12.4
   '@material-ui/icons': ^4.11.3
   '@material-ui/lab': 4.0.0-alpha.61
-  '@saleor/app-sdk': 0.13.2
+  '@saleor/app-sdk': 0.16.0
   '@saleor/macaw-ui': ^0.6.3
   '@sentry/nextjs': ^7.12.1
   '@types/node': ^18.7.16
@@ -52,7 +52,7 @@ dependencies:
   '@material-ui/core': 4.12.4_nylzxt5ale4dsv666zkb25cgtm
   '@material-ui/icons': 4.11.3_syzufrrnbgjhwvvotesawp6yai
   '@material-ui/lab': 4.0.0-alpha.61_syzufrrnbgjhwvvotesawp6yai
-  '@saleor/app-sdk': 0.13.2_c3hne4hwj64hb7tofigd3bvkji
+  '@saleor/app-sdk': 0.16.0_c3hne4hwj64hb7tofigd3bvkji
   '@saleor/macaw-ui': 0.6.3_3igskpsgnvdgn574z3phvz2joa
   '@sentry/nextjs': 7.12.1_next@12.3.0+react@18.2.0
   '@urql/exchange-auth': 1.0.0_graphql@16.5.0
@@ -1731,8 +1731,8 @@ packages:
       picomatch: 2.3.1
     dev: false
 
-  /@saleor/app-sdk/0.13.2_c3hne4hwj64hb7tofigd3bvkji:
-    resolution: {integrity: sha512-OqKlWZiWSEx9e1AdTGfZ0zSWLndoiALJ74o6pHgur/m5EBjP6Bmwi/8HoG2pOr8MhgwoECs+WwKEOzwt7theHQ==}
+  /@saleor/app-sdk/0.16.0_c3hne4hwj64hb7tofigd3bvkji:
+    resolution: {integrity: sha512-gph/DoJFnfmCkoAU9gLFqbq575BzQTl6KLokr+9YgNvfbkZZuHFn2DPpfR2J+G4AU/bFnR0y5zdA5UkvGajWoA==}
     peerDependencies:
       next: ^12
       react: '>=17'
@@ -1743,12 +1743,13 @@ packages:
       graphql: 16.6.0
       jose: 4.9.2
       next: 12.3.0_biqbaboplfbrettd7655fr4n2y
-      node-fetch: 3.2.10
+      node-fetch: 2.6.7
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       retes: 0.33.0
       uuid: 8.3.2
     transitivePeerDependencies:
+      - encoding
       - supports-color
     dev: false
 
@@ -5500,15 +5501,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-
-  /node-fetch/3.2.10:
-    resolution: {integrity: sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      data-uri-to-buffer: 4.0.0
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
-    dev: false
 
   /node-fetch/3.2.9:
     resolution: {integrity: sha512-/2lI+DBecVvVm9tDhjziTVjo2wmTsSxSk58saUYP0P/fRJ3xxtfMDY24+CKTkfm0Dlhyn3CSXNL0SoRiCZ8Rzg==}


### PR DESCRIPTION
As saleor-app-sdk have `getLayout` fix [released](https://github.com/saleor/saleor-app-sdk/releases/tag/v0.15.0) we can update it in package.lock and remove `ts-ignore`